### PR TITLE
backend now returns placeholder for no image

### DIFF
--- a/backend/models/Item.js
+++ b/backend/models/Item.js
@@ -45,6 +45,9 @@ ItemSchema.methods.updateFavoriteCount = function() {
 };
 
 ItemSchema.methods.toJSONFor = function(user) {
+  if (!this.image) {
+    this.image = "placeholder.png";
+  }
   return {
     slug: this.slug,
     title: this.title,


### PR DESCRIPTION
when called with the api, the backend will now return "placeholder.png" for the img if no image link is in the database
